### PR TITLE
add type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
+        "@types/react-color": "^3.0.6",
         "jest": "^29.5.0",
         "ts-jest": "^29.0.5"
       }
@@ -1586,10 +1587,29 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-color": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.6.tgz",
+      "integrity": "sha512-OzPIO5AyRmLA7PlOyISlgabpYUa3En74LP8mTMa0veCA719SvYQov4WLMsHvCgXP+L+KI9yGhYnqZafVGG0P4w==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*",
+        "@types/reactcss": "*"
+      }
+    },
     "node_modules/@types/react-dom": {
       "version": "18.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
       "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/reactcss": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/reactcss/-/reactcss-1.2.6.tgz",
+      "integrity": "sha512-qaIzpCuXNWomGR1Xq8SCFTtF4v8V27Y6f+b9+bzHiv087MylI/nTCqqdChNeWS7tslgROmYB7yeiruWX7WnqNg==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
+    "@types/react-color": "^3.0.6",
     "jest": "^29.5.0",
     "ts-jest": "^29.0.5"
   }


### PR DESCRIPTION
might be bending the rules, but prompt 32 was in a different conversation and chatGPT was assuming JavaScript vs TypeScript. If 32 had been in the same thread, we would definitely had imported the types. 